### PR TITLE
Relin key gen

### DIFF
--- a/crates/fhe/src/bfv/mod.rs
+++ b/crates/fhe/src/bfv/mod.rs
@@ -15,6 +15,7 @@ mod rgsw_ciphertext;
 pub mod traits;
 pub use ciphertext::Ciphertext;
 pub use encoding::Encoding;
+pub(crate) use keys::KeySwitchingKey;
 pub use keys::{EvaluationKey, EvaluationKeyBuilder, PublicKey, RelinearizationKey, SecretKey};
 pub use ops::{dot_product_scalar, Multiplicator};
 pub use parameters::{BfvParameters, BfvParametersBuilder};

--- a/crates/fhe/src/mbfv/protocols/mod.rs
+++ b/crates/fhe/src/mbfv/protocols/mod.rs
@@ -2,8 +2,10 @@
 
 mod public_key_gen;
 mod public_key_switch;
+mod relin_key_gen;
 mod secret_key_switch;
 
 pub use public_key_gen::PublicKeyShare;
 pub use public_key_switch::PublicKeySwitchShare;
+pub use relin_key_gen::{RelinKeyGenerator, RelinKeyShare};
 pub use secret_key_switch::{DecryptionShare, SecretKeySwitchShare};

--- a/crates/fhe/src/mbfv/protocols/public_key_gen.rs
+++ b/crates/fhe/src/mbfv/protocols/public_key_gen.rs
@@ -54,6 +54,7 @@ impl PublicKeyShare {
         // Create p0_i share
         let mut p0_share = -crp.clone();
         p0_share.disallow_variable_time_computations();
+        p0_share.change_representation(Representation::Ntt);
         p0_share *= s.as_ref();
         p0_share += e.as_ref();
 

--- a/crates/fhe/src/mbfv/protocols/relin_key_gen.rs
+++ b/crates/fhe/src/mbfv/protocols/relin_key_gen.rs
@@ -1,0 +1,354 @@
+//! Relin Key generation protocol.
+//!
+//! TODO:
+//! 1. Implement CRS->CRP common random polynomial + protocols around it
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use crate::bfv::{BfvParameters, KeySwitchingKey, RelinearizationKey, SecretKey};
+use crate::errors::Result;
+use crate::mbfv::Aggregate;
+use crate::Error;
+use fhe_math::rns::RnsContext;
+use fhe_math::rq::{traits::TryConvertFrom, Poly, Representation};
+use itertools::izip;
+use rand::{CryptoRng, RngCore};
+use zeroize::Zeroizing;
+
+pub trait Round: sealed::Sealed {}
+
+/// Marks the shares produced in round 1
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct R1;
+/// Marks the aggregated shares from round 1
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct R1Aggregated;
+/// Marks the shares from round 2
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct R2;
+
+impl Round for R1 {}
+impl Round for R1Aggregated {}
+impl Round for R2 {}
+
+/// The publicly disclosed shares of a Relin Key Gen protocol round.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct RelinKeyShare<R: Round = R1> {
+    pub(crate) par: Arc<BfvParameters>,
+    pub(crate) h0: Box<[Poly]>,
+    pub(crate) h1: Box<[Poly]>,
+    // This is a hack to get this done quickly. The `Aggregate` pattern
+    // doesn't really work for this protocol, it should be revised.
+    last_round: Option<Box<RelinKeyShare<R1Aggregated>>>,
+    _phantom_data: PhantomData<R>,
+}
+
+/// Each party uses the `RelinKeyGenerator` to generate their shares and participate in the
+/// "Protocol 2: RelinKeyGen" protocol detailed in Multiparty BFV (p6).
+pub struct RelinKeyGenerator<'a, 'b> {
+    sk_share: &'a SecretKey,
+    crp: &'b [Poly],
+    u: Zeroizing<Poly>,
+}
+
+impl<'a, 'b> RelinKeyGenerator<'a, 'b> {
+    /// Create a new relin key generator for a given party.
+    pub fn new<R: RngCore + CryptoRng>(
+        sk_share: &'a SecretKey,
+        crp: &'b [Poly],
+        rng: &mut R,
+    ) -> Result<Self> {
+        let par = sk_share.par.clone();
+        let ctx = par.ctx_at_level(0)?;
+        if crp.len() != ctx.moduli().len() {
+            Err(Error::DefaultError(
+                "The size of the CRP polynomial vector must equal the number of ciphertext moduli."
+                    .to_string(),
+            ))
+        } else {
+            let u = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
+            Ok(Self { sk_share, crp, u })
+        }
+    }
+
+    /// Generate shares for round 1
+    pub fn round_1<R: RngCore + CryptoRng>(&self, rng: &mut R) -> Result<RelinKeyShare<R1>> {
+        <RelinKeyShare<R1>>::new(self.sk_share, self.crp, &self.u, rng)
+    }
+
+    /// Generate shares for round 2
+    pub fn round_2<R: RngCore + CryptoRng>(
+        &self,
+        r1: &RelinKeyShare<R1Aggregated>,
+        rng: &mut R,
+    ) -> Result<RelinKeyShare<R2>> {
+        <RelinKeyShare<R2>>::new(self.sk_share, &self.u, r1, rng)
+    }
+}
+
+impl RelinKeyShare<R1> {
+    fn new<R: RngCore + CryptoRng>(
+        sk_share: &SecretKey,
+        crp: &[Poly],
+        u: &Zeroizing<Poly>,
+        rng: &mut R,
+    ) -> Result<Self> {
+        let par = sk_share.par.clone();
+
+        if crp.len() != par.ctx_at_level(0)?.moduli().len() {
+            Err(Error::DefaultError(
+                "The size of the CRP polynomial vector must equal the number of ciphertext moduli."
+                    .to_string(),
+            ))
+        } else {
+            let h0 = Self::generate_h0(sk_share, crp, u, rng)?;
+            let h1 = Self::generate_h1(sk_share, crp, rng)?;
+            Ok(Self {
+                par,
+                h0,
+                h1,
+                last_round: None,
+                _phantom_data: PhantomData,
+            })
+        }
+    }
+
+    fn generate_h0<R: RngCore + CryptoRng>(
+        sk_share: &SecretKey,
+        crp: &[Poly],
+        u: &Zeroizing<Poly>,
+        rng: &mut R,
+    ) -> Result<Box<[Poly]>> {
+        let par = sk_share.par.clone();
+        let ctx = par.ctx_at_level(0)?;
+
+        let mut s = Zeroizing::new(Poly::try_convert_from(
+            sk_share.coeffs.as_ref(),
+            ctx,
+            false,
+            Representation::PowerBasis,
+        )?);
+        s.change_representation(Representation::Ntt);
+        let rns = RnsContext::new(&sk_share.par.moduli[..crp.len()])?;
+        let h0 = crp
+            .iter()
+            .enumerate()
+            .map(|(i, a)| {
+                let w = rns.get_garner(i).unwrap();
+                let w_s = Zeroizing::new(w * s.as_ref());
+
+                let e = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
+
+                let mut h = a.clone();
+                h.disallow_variable_time_computations();
+                h.change_representation(Representation::Ntt);
+                h *= u.as_ref();
+
+                h += w_s.as_ref();
+                h += e.as_ref();
+                Ok(h)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(h0.into_boxed_slice())
+    }
+
+    fn generate_h1<R: RngCore + CryptoRng>(
+        sk_share: &SecretKey,
+        crp: &[Poly],
+        rng: &mut R,
+    ) -> Result<Box<[Poly]>> {
+        let par = sk_share.par.clone();
+        let ctx = par.ctx_at_level(0)?;
+        let mut s = Zeroizing::new(Poly::try_convert_from(
+            sk_share.coeffs.as_ref(),
+            ctx,
+            false,
+            Representation::PowerBasis,
+        )?);
+        s.change_representation(Representation::Ntt);
+
+        let h1 = crp
+            .iter()
+            .map(|a| {
+                let mut h = a.clone();
+                h.disallow_variable_time_computations();
+                h.change_representation(Representation::Ntt);
+                let e = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
+                h *= s.as_ref();
+                h += e.as_ref();
+                Ok(h)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(h1.into_boxed_slice())
+    }
+}
+
+impl Aggregate for RelinKeyShare<R1> {
+    type Output = RelinKeyShare<R1Aggregated>;
+
+    fn aggregate<I>(shares: I) -> Result<Self::Output>
+    where
+        I: IntoIterator<Item = Self>,
+    {
+        let mut shares = shares.into_iter();
+        let share = shares.next().ok_or(Error::TooFewValues(0, 1))?;
+        let mut h0 = share.h0;
+        let mut h1 = share.h1;
+        for sh in shares {
+            izip!(h0.iter_mut(), sh.h0.iter()).for_each(|(h0i, sh_h0i)| *h0i += sh_h0i);
+            izip!(h1.iter_mut(), sh.h1.iter()).for_each(|(h1i, sh_h1i)| *h1i += sh_h1i);
+        }
+
+        Ok(RelinKeyShare {
+            par: share.par,
+            h0,
+            h1,
+            last_round: None,
+            _phantom_data: PhantomData,
+        })
+    }
+}
+
+impl RelinKeyShare<R2> {
+    fn new<R: RngCore + CryptoRng>(
+        sk_share: &SecretKey,
+        u: &Zeroizing<Poly>,
+        r1: &RelinKeyShare<R1Aggregated>,
+        rng: &mut R,
+    ) -> Result<Self> {
+        let par = sk_share.par.clone();
+        let h0 = Self::generate_h0(sk_share, &r1.h0, rng)?;
+        let h1 = Self::generate_h1(sk_share, u, &r1.h1, rng)?;
+        Ok(Self {
+            par,
+            h0,
+            h1,
+            last_round: Some(Box::new(r1.clone())),
+            _phantom_data: PhantomData,
+        })
+    }
+
+    fn generate_h0<R: RngCore + CryptoRng>(
+        sk_share: &SecretKey,
+        r1_h0: &[Poly],
+        rng: &mut R,
+    ) -> Result<Box<[Poly]>> {
+        let par = sk_share.par.clone();
+        let ctx = par.ctx_at_level(0)?;
+
+        let mut s = Zeroizing::new(Poly::try_convert_from(
+            sk_share.coeffs.as_ref(),
+            ctx,
+            false,
+            Representation::PowerBasis,
+        )?);
+        s.change_representation(Representation::Ntt);
+        let h0 = r1_h0
+            .iter()
+            .map(|h| {
+                let e = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
+
+                let mut h_prime = h.clone();
+                h_prime.disallow_variable_time_computations();
+                h_prime.change_representation(Representation::Ntt);
+                h_prime *= s.as_ref();
+
+                h_prime += e.as_ref();
+                Ok(h_prime)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(h0.into_boxed_slice())
+    }
+
+    fn generate_h1<R: RngCore + CryptoRng>(
+        sk_share: &SecretKey,
+        u: &Zeroizing<Poly>,
+        r1_h1: &[Poly],
+        rng: &mut R,
+    ) -> Result<Box<[Poly]>> {
+        let par = sk_share.par.clone();
+        let ctx = par.ctx_at_level(0)?;
+        let mut s = Zeroizing::new(Poly::try_convert_from(
+            sk_share.coeffs.as_ref(),
+            ctx,
+            false,
+            Representation::PowerBasis,
+        )?);
+        s.change_representation(Representation::Ntt);
+
+        let u_s = Zeroizing::new(u.as_ref() - s.as_ref());
+
+        let h1 = r1_h1
+            .iter()
+            .map(|h| {
+                let mut h_prime = h.clone();
+                h_prime.disallow_variable_time_computations();
+                h_prime.change_representation(Representation::Ntt);
+                let e = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
+                h_prime *= u_s.as_ref();
+                h_prime += e.as_ref();
+                Ok(h_prime)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(h1.into_boxed_slice())
+    }
+}
+
+impl Aggregate for RelinKeyShare<R2> {
+    type Output = RelinearizationKey;
+
+    fn aggregate<I>(shares: I) -> Result<Self::Output>
+    where
+        I: IntoIterator<Item = Self>,
+    {
+        let mut shares = shares.into_iter();
+        let share = shares.next().ok_or(Error::TooFewValues(0, 1))?;
+        let par = share.par.clone();
+        let ctx = par.ctx_at_level(0)?.clone();
+        let r1 = share.last_round.ok_or(Error::DefaultError(
+            "Shares from round 2 should include a copy for the round 1 aggregation.".to_string(),
+        ))?;
+
+        // TODO this is correct right? write it out to be sure...
+        let mut h = share.h0;
+        izip!(h.iter_mut(), share.h1.iter()).for_each(|(hi, h1)| *hi += h1);
+        for sh in shares {
+            izip!(h.iter_mut(), sh.h0.iter(), sh.h1.iter()).for_each(|(hi, h0i, h1i)| {
+                *hi += h0i;
+                *hi += h1i;
+            });
+        }
+
+        let ksk = KeySwitchingKey {
+            par,
+            seed: None,
+            c0: h,
+            c1: r1.h1,
+            ciphertext_level: 0,
+            ctx_ciphertext: ctx.clone(),
+            ksk_level: 0,
+            ctx_ksk: ctx.clone(),
+        };
+        Ok(RelinearizationKey { ksk })
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::R1 {}
+    impl Sealed for super::R1Aggregated {}
+    impl Sealed for super::R2 {}
+}
+
+#[cfg(test)]
+mod tests {
+    // use super::*;
+    // use fhe_math::rq::{Poly, Representation};
+    // use fhe_traits::{FheEncoder, FheEncrypter};
+    // use rand::thread_rng;
+    //
+    // use crate::bfv::{BfvParameters, Encoding, Plaintext, SecretKey};
+    //
+    // const NUM_PARTIES: usize = 11;
+}

--- a/crates/fhe/src/mbfv/protocols/secret_key_switch.rs
+++ b/crates/fhe/src/mbfv/protocols/secret_key_switch.rs
@@ -42,6 +42,11 @@ impl SecretKeySwitchShare {
                 "Incompatible BFV parameters".to_string(),
             ));
         }
+        // Note: M-BFV implementation only supports ciphertext of length 2
+        if ct.c.len() != 2 {
+            return Err(Error::TooManyValues(ct.c.len(), 2));
+        }
+
         let par = sk_input_share.par.clone();
         let mut s_in = Zeroizing::new(Poly::try_convert_from(
             sk_input_share.coeffs.as_ref(),
@@ -68,9 +73,6 @@ impl SecretKeySwitchShare {
         )?);
 
         // Create h_i share
-        // TODO look at SecretKey::try_decrypt, probably need the `for i in 1..ct.c.len()` loop here.
-        // although I do think this is correct for len == 2, so for now:
-        assert_eq!(ct.c.len(), 2);
         let mut h_share = s_in.as_ref() - s_out.as_ref();
         h_share.disallow_variable_time_computations();
         h_share *= &ct.c[1];

--- a/crates/fhe/src/mbfv/protocols/secret_key_switch.rs
+++ b/crates/fhe/src/mbfv/protocols/secret_key_switch.rs
@@ -178,7 +178,7 @@ mod tests {
     use std::sync::Arc;
 
     use fhe_math::rq::{Poly, Representation};
-    use fhe_traits::{FheEncoder, FheEncrypter};
+    use fhe_traits::{FheDecoder, FheEncoder, FheEncrypter};
     use rand::thread_rng;
 
     use crate::{
@@ -305,6 +305,62 @@ mod tests {
 
                     let pt2 = DecryptionShare::aggregate(decryption_shares).unwrap();
                     assert_eq!(pt1, pt2);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn collective_keys_enable_homomorphic_addition() {
+        let mut rng = thread_rng();
+        for par in [
+            BfvParameters::default_arc(1, 8),
+            BfvParameters::default_arc(6, 8),
+        ] {
+            for level in 0..=par.max_level() {
+                for _ in 0..20 {
+                    let crp =
+                        Poly::random(par.ctx_at_level(0).unwrap(), Representation::Ntt, &mut rng);
+
+                    let mut parties: Vec<Party> = vec![];
+
+                    // Parties collectively generate public key
+                    for _ in 0..NUM_PARTIES {
+                        let sk_share = SecretKey::random(&par, &mut rng);
+                        let pk_share =
+                            PublicKeyShare::new(&sk_share, crp.clone(), &mut rng).unwrap();
+                        parties.push(Party { sk_share, pk_share })
+                    }
+                    let public_key =
+                        PublicKeyShare::aggregate(parties.iter().map(|p| p.pk_share.clone()))
+                            .unwrap();
+
+                    // Parties encrypt two plaintexts
+                    let a = par.plaintext.random_vec(par.degree(), &mut rng);
+                    let b = par.plaintext.random_vec(par.degree(), &mut rng);
+                    let mut expected = a.clone();
+                    par.plaintext.add_vec(&mut expected, &b);
+
+                    let pt_a =
+                        Plaintext::try_encode(&a, Encoding::poly_at_level(level), &par).unwrap();
+                    let pt_b =
+                        Plaintext::try_encode(&b, Encoding::poly_at_level(level), &par).unwrap();
+                    let ct_a = public_key.try_encrypt(&pt_a, &mut rng).unwrap();
+                    let ct_b = public_key.try_encrypt(&pt_b, &mut rng).unwrap();
+
+                    // and add them together
+                    let ct = Arc::new(&ct_a + &ct_b);
+
+                    // Parties perform a collective decryption
+                    let decryption_shares = parties
+                        .iter()
+                        .map(|p| DecryptionShare::new(&p.sk_share, &ct, &mut rng).unwrap());
+                    let pt = DecryptionShare::aggregate(decryption_shares).unwrap();
+
+                    assert_eq!(
+                        Vec::<u64>::try_decode(&pt, Encoding::poly_at_level(level)).unwrap(),
+                        expected
+                    );
                 }
             }
         }


### PR DESCRIPTION
This PR adds:

- Support for multiparty Relin Key Generation
- Errors when attempting to engage in protocols with ciphertexts greater than size 2
- Tests for homomorphic addition and multiplication in the multiparty context

Note: currently these RLK / multiplication tests only succeed when the public key CRP has "small" coefficients. Not sure why quite yet. In addition I also need to tweak the API; doesn't need to be perfect for this proof of concept but should be improved. Also will likely add the option to create RLKs at higher levels so that mod switching works.